### PR TITLE
docs: add FAQ. fixes #10

### DIFF
--- a/.github/FAQ.md
+++ b/.github/FAQ.md
@@ -1,0 +1,15 @@
+## Frequently Asked Questions
+
+#### The `[::]` URI is odd, what is that?
+
+With Node v8+, servers which inherit from [`net.Server`](https://nodejs.org/api/net.html#net_class_net_server) will automatically choose an IPv6 hostname when one is not specified. This plugin chooses not to enforce IPv4 when a host is not provided, but rather lets the underlying system behave according to its defaults.
+
+IPv6 can be unfamiliar territory for users, and the rules around IPv6 addresses are rather different than IPv4. According to [Wikipedia](https://en.wikipedia.org/wiki/IPv6_address#Representation):
+
+> The localhost (loopback) address, 0:0:0:0:0:0:0:1, and the IPv6 unspecified address, 0:0:0:0:0:0:0:0, are reduced to ::1 and ::, respectively.
+
+Since `net.Server` uses `0:0:0:0:0:0:0:0` (an unspecified address) by default, the resulting representation is `::`, which is the zero-compressed representation of the unspecified address. Since that's not at all valid in a browser's address bar, and `::` isn't a valid URI in that scope, `::` is represented as `[::]` in URI format. Hence, the URI you see from the server by default looks something like `http://[::]:55555`.
+
+#### Why doesn't the server default to `localhost`?
+
+This plugin is used by a plethora of different users with different needs. As soon as `localhost` is made the default, users will inevitably ask for `0.0.0.0`, `127.0.0.0`, etc. In order to avoid the debate entirely, we allow the Node subsystems and [`net.Server`](https://nodejs.org/api/net.html#net_class_net_server) to behave in their default manner.

--- a/README.md
+++ b/README.md
@@ -36,14 +36,10 @@ This module requires Node v10+. The client scripts in this module require [brows
 Using npm:
 
 ```console
-npm install webpack-plugin-serve --save-dev
+npm install webpack-nano webpack-plugin-serve --save-dev
 ```
 
-Using yarn:
-
-```console
-yarn add webpack-plugin-serve --dev
-```
+_Note: We recommend using [webpack-nano](https://github.com/shellscape/webpack-nano), a very tiny, very clean webpack CLI._
 
 ## Usage
 
@@ -62,15 +58,16 @@ module.exports = {
   ...
   plugins: [
     new Serve(options)
-  ]
+  ],
+  watch: true  // ← important: webpack and the server will continue to run in watch mode
 };
 
 ```
 
-And run `webpack` in watch mode:
+And run `webpack`:
 
 ```console
-$ npx webpack --watch
+$ npx wp
 ```
 
 ## Options
@@ -113,6 +110,8 @@ Type: `String | Promise`<br>
 Default: `::` for IPv6, `127.0.0.1` for IPv4
 
 Sets the host the server should listen from. Users may choose to set this to a `Promise`, or a `Function` which returns a `Promise` for situations in which the server needs to wait for a host to resolve.
+
+_Note: The default URI is `http://[::]:{port}`. For more info, please read [the FAQ](.github/FAQ.md)._
 
 ### `http2`
 Type: `boolean` | [http2 options]() | [https2 options]()


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [x] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

This adds a FAQ document that we can continue to add to for common questions that pop up in issues moving forward. To start, it contains two questions related to #10, and explains the default URI and why we chose not to default to `localhost` or other IPv4 address.

This also updates the README slightly to point users to that document, and also to recommend `webpack-nano` by default.