### PR TITLE
fix: hmr plugin duplication detection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -101,7 +101,7 @@ class WebpackPluginServe extends EventEmitter {
         hmrPlugin.apply(compiler);
       } else {
         this.log.warn(
-           'Note: webpack-plugin-serve adds HotModuleReplacementPlugin automatically. It can be safely removed from your config'
+          'Note: webpack-plugin-serve adds HotModuleReplacementPlugin automatically. It can be safely removed from your config'
         );
       }
     }


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

In cases where user already has an instance of `HotModuleReplacementPlugin`, we were inserting another instance which caused `Maximum call stack size exceeded` errors during hot reload.