### PR TITLE
fix: hmr filenames

### DIFF
--- a/lib/hmr-plugin.js
+++ b/lib/hmr-plugin.js
@@ -1,0 +1,68 @@
+const { HotModuleReplacementPlugin } = require('webpack');
+
+const chunkFilename = 'wps-hmr.js';
+const mainFilename = 'wps-hmr.json';
+
+const addPlugin = (compiler) => {
+  const hmrPlugin = new HotModuleReplacementPlugin();
+  // eslint-disable-next-line no-param-reassign
+  compiler.options.output = Object.assign(compiler.options.output, {
+    hotUpdateChunkFilename: chunkFilename,
+    hotUpdateMainFilename: mainFilename
+  });
+  hmrPlugin.apply(compiler);
+};
+
+const hookPlugin = (compiler) => {
+  const makePattern = (assetName) =>
+    new RegExp(assetName.replace(/\[\w+\]/g, '(\\w+)').replace(/\./g, '\\.'));
+
+  compiler.hooks.compilation.tap('wps', (compilation) => {
+    compilation.hooks.additionalChunkAssets.intercept({
+      register: (hook) => {
+        if (hook.name === 'HotModuleReplacementPlugin') {
+          const og = hook.fn;
+          // eslint-disable-next-line no-param-reassign
+          hook.fn = (...args) => {
+            const { assets } = compilation;
+            const { hotUpdateChunkFilename, hotUpdateMainFilename } = compiler.options.output;
+            const chunkPattern = makePattern(hotUpdateChunkFilename);
+            const mainPattern = makePattern(hotUpdateMainFilename);
+
+            for (const assetName of Object.keys(assets)) {
+              if (chunkPattern.test(assetName)) {
+                assets[chunkFilename] = assets[assetName];
+                delete assets[assetName];
+              } else if (mainPattern.test(assetName)) {
+                assets[mainFilename] = assets[assetName];
+                delete assets[assetName];
+              }
+            }
+
+            const result = og(...args);
+
+            return result;
+          };
+        }
+        return hook;
+      }
+    });
+  });
+};
+
+const init = (compiler) => {
+  const hasHMRPlugin = compiler.options.plugins.some(
+    (plugin) => plugin instanceof HotModuleReplacementPlugin
+  );
+  if (!hasHMRPlugin) {
+    addPlugin(compiler);
+    return;
+  }
+  this.log.warn(
+    'webpack-plugin-serve adds HotModuleReplacementPlugin automatically. Please remove it from your config.'
+  );
+
+  hookPlugin(compiler);
+};
+
+module.exports = { init };

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,8 +11,9 @@
 const EventEmitter = require('events');
 
 const Koa = require('koa');
-const { DefinePlugin, HotModuleReplacementPlugin, ProgressPlugin } = require('webpack');
+const { DefinePlugin, ProgressPlugin } = require('webpack');
 
+const { init: initHmrPlugin } = require('./hmr-plugin');
 const { getLogger } = require('./log');
 const { start } = require('./server');
 
@@ -86,61 +87,8 @@ class WebpackPluginServe extends EventEmitter {
       return;
     }
 
-    const chunkFilename = 'wps-hmr.js';
-    const mainFilename = 'wps-hmr.json';
-
     if (this.options.hmr) {
-      const hmrPlugin = new HotModuleReplacementPlugin();
-      const hasHMRPlugin = compiler.options.plugins.some(
-        (plugin) => plugin instanceof HotModuleReplacementPlugin
-      );
-      if (!hasHMRPlugin) {
-        // eslint-disable-next-line no-param-reassign
-        compiler.options.output = Object.assign(compiler.options.output, {
-          hotUpdateChunkFilename: chunkFilename,
-          hotUpdateMainFilename: mainFilename
-        });
-        hmrPlugin.apply(compiler);
-      } else {
-        this.log.warn(
-          'webpack-plugin-serve adds HotModuleReplacementPlugin automatically. Please remove it from your config.'
-        );
-
-        const makePattern = (assetName) =>
-          new RegExp(assetName.replace(/\[\w+\]/g, '(\\w+)').replace(/\./g, '\\.'));
-
-        compiler.hooks.compilation.tap('wps', (compilation) => {
-          compilation.hooks.additionalChunkAssets.intercept({
-            register: (hook) => {
-              if (hook.name === 'HotModuleReplacementPlugin') {
-                const og = hook.fn;
-                // eslint-disable-next-line no-param-reassign
-                hook.fn = (...args) => {
-                  const { assets } = compilation;
-                  const { hotUpdateChunkFilename, hotUpdateMainFilename } = compiler.options.output;
-                  const chunkPattern = makePattern(hotUpdateChunkFilename);
-                  const mainPattern = makePattern(hotUpdateMainFilename);
-
-                  for (const assetName of Object.keys(assets)) {
-                    if (chunkPattern.test(assetName)) {
-                      assets[chunkFilename] = assets[assetName];
-                      delete assets[assetName];
-                    } else if (mainPattern.test(assetName)) {
-                      assets[mainFilename] = assets[assetName];
-                      delete assets[assetName];
-                    }
-                  }
-
-                  const result = og(...args);
-
-                  return result;
-                };
-              }
-              return hook;
-            }
-          });
-        });
-      }
+      initHmrPlugin(compiler);
     }
 
     const { compile, done, invalid, watchClose, watchRun } = compiler.hooks;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [x] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

### Please Describe Your Changes

Detection of whether or not an `HotModuleReplacementPlugin` was already in the config was being performed, but reusing the plugin that had been added outside of webpack-plugin-serve wasn't working as the chunk and main HMR filenames weren't what the server plugin expects. This PR introduces conditional hook interception so we can force the HMR filenames that we expect.