### PR TITLE
fix: typo on progress which broke the overlay

### DIFF
--- a/lib/overlays/progress-minimal.js
+++ b/lib/overlays/progress-minimal.js
@@ -13,7 +13,7 @@ const { addCss, addHtml } = require('./util');
 const ns = 'wps-progress-minimal';
 const html = `
 <div id="${ns}" class="${ns}-hidden">
-  <div class="${ns}-bar"></div>
+  <div id="${ns}-bar"></div>
 </div>
 `;
 const css = `


### PR DESCRIPTION

This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [X] no

We forgot to move from class to id when refactored the code.