### PR TITLE
fix: destructuring of undefined or null variables. fixes #46

### DIFF
--- a/lib/client/hmr.js
+++ b/lib/client/hmr.js
@@ -10,7 +10,6 @@
 */
 const { error, info, refresh, warn } = require('./log');
 
-const { apply, check, status } = module.hot || {};
 let latest = true;
 
 const hmr = {
@@ -27,6 +26,8 @@ const hmr = {
 };
 
 const replace = async (hash) => {
+  const { apply, check, status } = module.hot;
+
   if (hash) {
     // eslint-disable-next-line no-undef
     latest = hash.includes(__webpack_hash__);

--- a/lib/client/hmr.js
+++ b/lib/client/hmr.js
@@ -10,7 +10,7 @@
 */
 const { error, info, refresh, warn } = require('./log');
 
-const { apply, check, status } = module.hot;
+const { apply, check, status } = module.hot || {};
 let latest = true;
 
 const hmr = {


### PR DESCRIPTION
This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [X] no

If yes, please describe the breakage.

### Please Describe Your Changes
When destructuring `module.hot`, when `hmr:false`, `module.hot` does not exist, so it would throw an error. 

Fix #46 