### PR TITLE
fix: add close passthrough method to ClientSocket #59

### DIFF
--- a/lib/client/ClientSocket.js
+++ b/lib/client/ClientSocket.js
@@ -30,6 +30,10 @@ class ClientSocket {
     this.socket.addEventListener(...args);
   }
 
+  close() {
+    this.socket.close();
+  }
+
   connect() {
     if (this.socket) {
       delete this.socket;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Fixes #59. When implementing the `ClientSocket` class for reconnectivity, we neglected to add a `close` method to passthrough to the underlying socket. This generated a harmless error in both the browser console and the system console/terminal. 
