### PR TITLE
fix: use static hmr filenames

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,26 @@
+/*
+  Copyright © 2018 Andrew Powell
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of this Source Code Form.
+*/
+class WebpackPluginServeError extends Error {
+  constructor(...args) {
+    super(...args);
+    this.name = 'WebpackPluginServeError';
+  }
+}
+
+class PluginExistsError extends WebpackPluginServeError {
+  constructor(...args) {
+    super(...args);
+    this.name = 'PluginExistsError';
+    this.code = 'ERR_PLUGIN_EXISTS';
+  }
+}
+
+module.exports = { PluginExistsError, WebpackPluginServeError };

--- a/lib/hmr-plugin.js
+++ b/lib/hmr-plugin.js
@@ -11,115 +11,18 @@
 /* eslint no-param-reassign: off */
 const { HotModuleReplacementPlugin } = require('webpack');
 
-const chunkPlaceholder = 'wps-hmr.js';
-const mainPlaceholder = 'wps-hmr.json';
-
 const addPlugin = (compiler) => {
   const hmrPlugin = new HotModuleReplacementPlugin();
-  // eslint-disable-next-line no-param-reassign
-  compiler.options.output = Object.assign(compiler.options.output, {
-    hotUpdateChunkFilename: chunkPlaceholder,
-    hotUpdateMainFilename: mainPlaceholder
-  });
   hmrPlugin.apply(compiler);
 };
 
-const intercept = (targetHook, targetName, fn) => {
-  targetHook.intercept({
-    register: (hook) => {
-      if (hook.name === targetName) {
-        fn(hook, hook.fn);
-      }
-      return hook;
-    }
-  });
-};
-
-const hookPlugin = (compiler) => {
-  const makePattern = (assetName) =>
-    new RegExp(`${assetName}$`.replace(/\[\w+\]/g, '(\\w+)').replace(/\./g, '\\.'));
-
-  compiler.hooks.compilation.tap('wps', (compilation) => {
-    const { mainTemplate } = compilation;
-    const { assetPath, hashForChunk, hotBootstrap } = mainTemplate.hooks;
-    const { additionalChunkAssets } = compilation.hooks;
-    let currentChunk;
-
-    // fixes #55. html-webpack-plugin uses a child compiler which alters the order of chunk
-    // processing, calling assetPath before hotBootstrap.
-    hashForChunk.tap('wps', (hash, chunk) => {
-      currentChunk = chunk;
-    });
-
-    intercept(hotBootstrap, 'JsonpMainTemplatePlugin', (hook, ogFn) => {
-      hook.fn = (source, chunk, hash) => {
-        currentChunk = chunk;
-        return ogFn(source, chunk, hash);
-      };
-    });
-
-    intercept(assetPath, 'TemplatedPathPlugin', (hook, ogFn) => {
-      const chunkTest = `"${chunkPlaceholder}"`;
-      const mainTest = `"${mainPlaceholder}"`;
-
-      hook.fn = (path, data) => {
-        // html-webpack-plugin doesn't call the same hooks that normal assets do. currentChunk will
-        // always be undefined for its files.
-        if (!currentChunk) {
-          return ogFn(path, data);
-        }
-
-        const { hotUpdateChunkFilename, hotUpdateMainFilename } = compiler.options.output;
-
-        if (path === chunkTest) {
-          path = `"${compiler.wpsId}-${currentChunk.id}-${chunkPlaceholder}"`;
-          compiler.options.output = Object.assign(compiler.options.output, {
-            hotUpdateChunkFilename: path.slice(1, -1),
-            oldHotUpdateChunkFilename: hotUpdateChunkFilename
-          });
-        } else if (path === mainTest) {
-          path = `"${compiler.wpsId}-${currentChunk.id}-${mainPlaceholder}"`;
-          compiler.options.output = Object.assign(compiler.options.output, {
-            hotUpdateMainFilename: path.slice(1, -1),
-            oldHotUpdateMainFilename: hotUpdateMainFilename
-          });
-        }
-
-        return ogFn(path, data);
-      };
-    });
-
-    intercept(additionalChunkAssets, 'HotModuleReplacementPlugin', (hook, ogFn) => {
-      hook.fn = (...args) => {
-        const result = ogFn(...args);
-
-        const { assets } = compilation;
-        const {
-          hotUpdateChunkFilename,
-          hotUpdateMainFilename,
-          oldHotUpdateChunkFilename,
-          oldHotUpdateMainFilename
-        } = compiler.options.output;
-        const chunkPattern = makePattern(oldHotUpdateChunkFilename);
-        const mainPattern = makePattern(oldHotUpdateMainFilename);
-
-        for (const assetName of Object.keys(assets)) {
-          if (chunkPattern.test(assetName)) {
-            assets[hotUpdateChunkFilename] = assets[assetName];
-            delete assets[assetName];
-          } else if (mainPattern.test(assetName)) {
-            assets[hotUpdateMainFilename] = assets[assetName];
-            delete assets[assetName];
-          }
-        }
-
-        return result;
-      };
-    });
-  });
-};
-
 const init = function init(compiler, log) {
+  // eslint-disable-next-line no-param-reassign
+  compiler.options.output = Object.assign(compiler.options.output, {
+    hotUpdateChunkFilename: `${compiler.wpsId}-[id]-wps-hmr.js`,
+    hotUpdateMainFilename: `${compiler.wpsId}-wps-hmr.json`
+  });
+
   const hasHMRPlugin = compiler.options.plugins.some(
     (plugin) => plugin instanceof HotModuleReplacementPlugin
   );
@@ -130,8 +33,6 @@ const init = function init(compiler, log) {
       'webpack-plugin-serve adds HotModuleReplacementPlugin automatically. Please remove it from your config.'
     );
   }
-
-  hookPlugin(compiler);
 };
 
 module.exports = { init };

--- a/lib/hmr-plugin.js
+++ b/lib/hmr-plugin.js
@@ -8,8 +8,9 @@
   The above copyright notice and this permission notice shall be
   included in all copies or substantial portions of this Source Code Form.
 */
-/* eslint no-param-reassign: off */
 const { HotModuleReplacementPlugin } = require('webpack');
+
+const { PluginExistsError } = require('./errors');
 
 const addPlugin = (compiler) => {
   const hmrPlugin = new HotModuleReplacementPlugin();
@@ -29,8 +30,11 @@ const init = function init(compiler, log) {
   if (!hasHMRPlugin) {
     addPlugin(compiler);
   } else {
-    log.warn(
+    log.error(
       'webpack-plugin-serve adds HotModuleReplacementPlugin automatically. Please remove it from your config.'
+    );
+    throw new PluginExistsError(
+      'HotModuleReplacementPlugin exists in the specified configuration.'
     );
   }
 };

--- a/test/fixtures/simple/index.html
+++ b/test/fixtures/simple/index.html
@@ -1,7 +1,7 @@
 <!doctype>
 <html>
   <head>
-    <title>fixture: simple</title>
+    <title>fixture: multicompiler</title>
   </head>
   <body>
     <main></main>


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [x] metadata

### Breaking Changes?

- [x] yes
- [ ] no

This PR introduces a breaking change, though it's not likely to impact our modest user base at this time: if a user has introduced a `HotModuleReplacementPlugin` instance to the configuration's `plugins` before the `WebpackPluginServe` instance, this plugin with throw an exception.

Previously, we were trying to be cute and work around that by modifying webpack internals. That was a noble goal initially, but with the introduction of MultiCompiler support, the complexity of the code required to do so increased significantly, and to make that work with #60 will add even more. All of that points to increased fragility of our code to work around things in webpack. Keeping that complexity will ultimately make upgrades harder for us moving forward.

Throwing an error requesting the user remove the plugin is ultimately a simpler solution for all parties.

### Please Describe Your Changes

Fixes #60.

So! When implementing MultiCompiler support, it appears I jumped the shark a bit. One component of MultiCompiler support was that we started tagging each compiler with a UUID of our own. That was a late addition to the overall solution, and came after hooking `additionalChunkAssets`, `chunkHash`, and a few others - with the goal of overriding the HMR filename options.
