### PR TITLE
docs: add custom open uri recipe

### DIFF
--- a/recipes/open-custom-uri.md
+++ b/recipes/open-custom-uri.md
@@ -1,0 +1,34 @@
+## 🍲 Opening a Custom URI
+
+The [`open`](https://github.com/shellscape/webpack-plugin-serve#open) option provides users with the ability to instruct the plugin to open the root URI of an application after the server begins listening. In some circumstances users might need to open a custom URI. This can be done relatively quickly.
+
+_Note: `webpack-plugin-serve` endeavors to directly pass-through options for dependencies, rather than wrap custom options sets, parse them, and pass them onto dependencies. Such is the case for the `opn` module and the `open` option._
+
+### Meat and Potatoes
+
+To get started, your `webpack` configuration should already be setup and building successfully without using `webpack-plugin-serve`. Next, let's get the plugin setup for opening a custom URI:
+
+```js
+const open = require('opn');
+const { WebpackPluginServe } = require('webpack-plugin-serve');
+
+const serve = new WebpackPluginServe();
+
+// we'll listen for the `listening` event, which tells us the server is up and running
+serve.on('listening', () => {
+  const uri = 'http://localhost:5555/#/local';
+  const opts = {};
+  opn(uri, opts);
+});
+
+// webpack.config.js
+module.exports = {
+  plugins: [ serve ]
+};
+```
+
+And that's all there is to it.
+
+### 🍰 Dessert
+
+You deserve some cookies (or biscuits or whatever they're call in your neck of the woods).


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [x] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

Adds a recipe for opening a custom uri, rather than the uri of the root of the application. Resolves #64 
