### PR TITLE
fix: z-index on overlays set to max allowed. fix #81

### DIFF
--- a/lib/client/overlays/progress-minimal.js
+++ b/lib/client/overlays/progress-minimal.js
@@ -23,7 +23,7 @@ const css = `
   left: 0;
   height: 4px;
   width: 100vw;
-  z-index: 2147483647;
+  z-index: 2147483645;
 }
 
 #${ns}-bar {

--- a/lib/client/overlays/progress-minimal.js
+++ b/lib/client/overlays/progress-minimal.js
@@ -23,6 +23,7 @@ const css = `
   left: 0;
   height: 4px;
   width: 100vw;
+  z-index: 2147483647;
 }
 
 #${ns}-bar {

--- a/lib/client/overlays/progress.js
+++ b/lib/client/overlays/progress.js
@@ -21,7 +21,7 @@ const css = `
   right: 5%;
   top: 5%;
   transition: opacity .25s ease-in-out;
-  z-index: 2147483647;
+  z-index: 2147483645;
 }
 
 #${ns}-bg {

--- a/lib/client/overlays/progress.js
+++ b/lib/client/overlays/progress.js
@@ -21,7 +21,7 @@ const css = `
   right: 5%;
   top: 5%;
   transition: opacity .25s ease-in-out;
-  z-index: 1000;
+  z-index: 2147483647;
 }
 
 #${ns}-bg {
@@ -45,7 +45,7 @@ const css = `
 }
 
 #${ns}-percent-value {
-  alignment-baseline: middle;
+  dominant-baseline: middle;
   text-anchor: middle;
 }
 

--- a/lib/client/overlays/status.js
+++ b/lib/client/overlays/status.js
@@ -32,7 +32,7 @@ const css = `
   transform: translateX(-50%);
   transition: opacity .25s ease-in-out;
   width: 95%;
-  z-index: 2147483647;
+  z-index: 2147483645;
 }
 
 @keyframes ${ns}-hidden-display {

--- a/lib/client/overlays/status.js
+++ b/lib/client/overlays/status.js
@@ -32,6 +32,7 @@ const css = `
   transform: translateX(-50%);
   transition: opacity .25s ease-in-out;
   width: 95%;
+  z-index: 2147483647;
 }
 
 @keyframes ${ns}-hidden-display {


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [X] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [X] no

As #81 suggested and we also had discussed before on the approach we should use to set those overlays on top of every possible scenario, be aware that, i preferred to decrease -2 on the max `z-index` allowed as a cautions action, to not walk on the edge every time, so we have a margin of error.

