### PR TITLE
feat: static middleware options

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ If a value of `'minimal'` is set, the progress indicator will render as a small,
 Type: `String | Array(String)`<br>
 Default: `compiler.context`
 
-Sets the directory(s) from which static files will be served. Bundles will be served from the `output` config setting.
+Sets the directory(s) from which static files will be served. Bundles will be served from the `output` config setting. For specifying options for static file directories, please see [`middleware > static`](#middleware).
 
 ### `status`
 Type: `boolean`<br>

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ declare module 'webpack-plugin-serve' {
   interface Builtins {
     proxy: (args: HttpProxyMiddlewareConfig) => Proxy;
     compress: (opts: CompressOptions) => void;
-    static: (opts: KoaStaticOptions) => void;
+    static: (paths: Array<String>, opts?: KoaStaticOptions) => void;
     historyFallback: (opts: HistoryApiFallbackOptions) => void;
     websocket: () => void;
     four0four: (fn?: (ctx: Koa.Context) => void) => void;

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -94,11 +94,11 @@ const getBuiltins = (app, options) => {
     }
   };
 
-  const statik = (root) => {
+  const statik = (root, opts = {}) => {
     const paths = [].concat(root || options.static);
     staticPaths = paths;
     for (const path of paths) {
-      app.use(koaStatic(path));
+      app.use(koaStatic(path, opts));
     }
   };
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] tests
- [x] documentation
- [x] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

Resolves #80. Adds the ability to pass options for `koa-static` via the `builtins.static` middleware.