### PR TITLE
chore(meta): Add support for node 10.15.0 and above in 'engines'

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "typings": "index.d.ts",
   "engines": {
-    "node": ">= 8.0.0 < 9.0.0 || >= 10.0.0 < 10.14.0 || >= 11.0.0"
+    "node": ">= 8.0.0 < 9.0.0 || >= 10.0.0 < 10.14.0 || >= 10.15.0"
   },
   "scripts": {
     "ci:coverage": "nyc npm run test && nyc report --reporter=text-lcov > coverage.lcov",


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [x] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

Add support for node 10.15.0 and above in 'engines', since 10.15 fixes #47 by way of https://github.com/nodejs/node/commit/1aea1e3634de7331f670f0594c023ca7c64a759f
