### PR TITLE
feat: add client.silent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Type: `Boolean`
 
 If `true`, instructs the client to attempt to reconnect all `WebSockets` when their connects are interrupted, usually as a result of the server being stopped and/or restarted. _Note: This can be very spammy in the browser console, as there is no way to suppress error messages from the browser when a `WebSocket` fails to connect._
 
+#### `client.silent`
+Type: `Boolean`
+
+If `true`, instructs the client not to log anything to the console.
+
+
 ### `compress`
 Type: `Boolean`<br>
 Default: `false`

--- a/client.js
+++ b/client.js
@@ -21,7 +21,7 @@
   try {
     options = ʎɐɹɔosǝʌɹǝs;
   } catch (e) {
-    const log = require('./lib/client/log');
+    const { log } = require('./lib/client/log');
     log.error(
       'The entry for webpack-plugin-serve was included in your build, but it does not appear that the plugin was. Please check your configuration.'
     );

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -12,7 +12,8 @@
 const run = (buildHash, options) => {
   const { ClientSocket } = require('./ClientSocket');
   const { replace } = require('./hmr');
-  const { error, info, warn } = require('./log');
+  const { log, silent } = require('./log');
+  const { error, info, warn } = options.silent ? silent : log;
 
   const { address, client = {}, progress, secure, status } = options;
   const protocol = secure ? 'wss' : 'ws';

--- a/lib/client/log.js
+++ b/lib/client/log.js
@@ -15,5 +15,11 @@ const log = {
   refresh: 'Please refresh the page',
   warn: warn.bind(console, '⬡ wps:')
 };
+const noop = () => {};
+const silent = {
+  error: noop,
+  info: noop,
+  warn: noop
+};
 
-module.exports = log;
+module.exports = { log, silent };


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] tests
- [x] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

Fixes #88. Adds a `client.silent` option to silence console output in the browser/client. 