### PR TITLE
fix: strip accept header when using history-api-fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ If `true`, enables History API Fallback via [`connect-history-api-fallback`](htt
 
 This setting can be handy when using the HTML5 History API; `index.html` page will likely have to be served in place of any 404 responses from the server, specially when developing Single Page Applications.
 
+_Note: The `Accept` header is explicitly stripped from the `/wps` WebSocket path when using `historyFallback`, due to [an issue](https://github.com/shellscape/webpack-plugin-serve/issues/94) with how Firefox and the middleware interact.
+
 ### `hmr`
 Type: `boolean`<br>
 Default: `true`

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -88,8 +88,28 @@ const getBuiltins = (app, options) => {
     }
   };
 
+  const four0four = (fn = () => {}) => {
+    app.use(async (ctx, next) => {
+      await next();
+      if (ctx.status === 404) {
+        render404(ctx);
+        fn(ctx);
+      }
+    });
+  };
+
   const historyFallback = () => {
     if (options.historyFallback) {
+      // https://github.com/shellscape/webpack-plugin-serve/issues/94
+      // When using Firefox, the browser sends an accept header for /wps when using connect-history-api-fallback
+      app.use(async (ctx, next) => {
+        if (ctx.path.match(/^\/wps/)) {
+          const { accept, ...headers } = ctx.request.header;
+          ctx.request.header = headers; // eslint-disable-line no-param-reassign
+        }
+        await next();
+      });
+
       app.use(convert(historyApiFallback(options.historyFallback)));
     }
   };
@@ -102,19 +122,8 @@ const getBuiltins = (app, options) => {
     }
   };
 
-  const websocket = () => app.use(wsMiddleware);
-
   const proxy = (...args) => convert(httpProxyMiddleware(...args));
-
-  const four0four = (fn = () => {}) => {
-    app.use(async (ctx, next) => {
-      await next();
-      if (ctx.status === 404) {
-        render404(ctx);
-        fn(ctx);
-      }
-    });
-  };
+  const websocket = () => app.use(wsMiddleware);
 
   proxy.skip = true;
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [x] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

Fixes #94. When using Firefox with the `historyFallback` option (`connect-history-api-fallback`), the `/wps` WebSocket path is incorrectly given an `Accept` header, which makes the middleware think it's a directory index. The added middleware strips that header in that event, preventing the error, only when the `historyFallback` option is used.