### PR TITLE
fix(routes): Allow HMR with warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ npm-debug.log
 coverage
 node_modules
 .eslintcache
+.idea
 
 test/**/output*
 output.js

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -46,8 +46,9 @@ const setupRoutes = function setupRoutes() {
         socket.lastHash = hash;
 
         const { errors = [], warnings = [] } = stats.toJson(statsOptions);
+        const hasErrors = Boolean(errors.length);
 
-        if (errors.length || warnings.length) {
+        if (hasErrors || warnings.length) {
           socket.send(
             prep({
               action: 'problems',
@@ -60,7 +61,7 @@ const setupRoutes = function setupRoutes() {
             })
           );
 
-          return;
+          if (hasErrors) return;
         }
 
         if (options.hmr || options.liveReload) {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

We have two message types, which contains information about problems when Application building. There are warnings and errors. Currently when error or warning are detected, `webpack-plugin-serve` doesn't replace changed files. This PR allow apply changes to files by HMR if get any warning, because warning it's not critical problem, which affect on build process. Warnings never stopping building process. For example, warning from ESLint (eslint-loader)