### PR TITLE
fix: handle a potential uncaughtException

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -84,6 +84,9 @@ const setupRoutes = function setupRoutes() {
       };
 
       socket.progress = (data) => {
+        if (socket.readyState !== 1) {
+          return;
+        }
         socket.send(prep({ action: 'progress', data }));
       };
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Fixes a case in which we tried to send data through a socket that isn't connected due to the client being in the middle of a page reload (and thus closing the connection). This exception killed the whole webpack process.

Example stacktrace:

```
uncaughtException Error: WebSocket is not open: readyState 2 (CLOSING)
    at WebSocket.send (/app/node_modules/ws/lib/websocket.js:322:19)
    at WebpackPluginServe.socket.progress (/app/node_modules/webpack-plugin-serve/lib/routes.js:87:16)
    at WebpackPluginServe.emit (events.js:189:13)
    at ProgressPlugin (/app/node_modules/webpack-plugin-serve/lib/index.js:212:16)
    at update (/app/node_modules/webpack/lib/ProgressPlugin.js:151:5)
    at moduleAdd (/app/node_modules/webpack/lib/ProgressPlugin.js:163:5)
    at SyncHook.eval (eval at create (/app/node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:11:1)
    at Compilation.buildModule (/app/node_modules/webpack/lib/Compilation.js:634:26)
    at factory.create (/app/node_modules/webpack/lib/Compilation.js:884:14)
    at factory (/app/node_modules/webpack/lib/NormalModuleFactory.js:405:6)
    at hooks.afterResolve.callAsync (/app/node_modules/webpack/lib/NormalModuleFactory.js:155:13)
    at AsyncSeriesWaterfallHook.eval [as callAsync] (eval at create (/app/node_modules/tapable/lib/HookCodeFactory.js:32:10), <anonymous>:6:1)
    at resolver (/app/node_modules/webpack/lib/NormalModuleFactory.js:138:29)
    at process.nextTick (/app/node_modules/webpack/lib/NormalModuleFactory.js:342:9)
    at process._tickCallback (internal/process/next_tick.js:61:11)
```
