### PR TITLE
handle uncaughtException

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -71,13 +71,13 @@ const setupRoutes = function setupRoutes() {
         }
       };
 
-      socket.invalid = (filePath = '<unknown>', compiler) => {
+      socket.invalid = (filePath, compiler) => {
         if (socket.readyState === 3) {
           return;
         }
 
         const context = compiler.context || compiler.options.context || process.cwd();
-        const fileName = filePath.replace(context, '');
+        const fileName = typeof filePath === 'string' ? filePath.replace(context, '') : '<unknown>';
         const { wpsId } = compiler;
 
         socket.send(prep({ action: 'invalid', data: { fileName, wpsId } }));

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -71,13 +71,13 @@ const setupRoutes = function setupRoutes() {
         }
       };
 
-      socket.invalid = (filePath, compiler) => {
+      socket.invalid = (filePath = '<unknown>', compiler) => {
         if (socket.readyState === 3) {
           return;
         }
 
         const context = compiler.context || compiler.options.context || process.cwd();
-        const fileName = typeof filePath === 'string' ? filePath.replace(context, '') : '<unknown>';
+        const fileName = filePath.replace && filePath.replace(context, '') || filePath;
         const { wpsId } = compiler;
 
         socket.send(prep({ action: 'invalid', data: { fileName, wpsId } }));


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

I do not know exactly what is the case in which this issue occurs, however this change should be enough to fix the issue.

Stacktrace:

```
uncaughtException TypeError: filePath.replace is not a function
    at WebpackPluginServe.socket.invalid (/project/node_modules/webpack-plugin-serve/lib/routes.js:80:35)
    at WebpackPluginServe.emit (events.js:194:15)
    at invalid.tap (/project/node_modules/webpack-plugin-serve/lib/index.js:155:41)
    at SyncHook.eval (eval at create (/project/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:7:1)
    at Watchpack.watcher.compiler.watchFileSystem.watch (/project/node_modules/webpack/lib/Watching.js:139:33)
    at Object.onceWrapper (events.js:277:13)
    at Watchpack.emit (events.js:189:13)
    at Watchpack._onChange (/project/node_modules/watchpack/lib/watchpack.js:118:7)
    at Watchpack.<anonymous> (/project/node_modules/watchpack/lib/watchpack.js:109:8)
    at Watcher.emit (events.js:189:13)
    at /project/node_modules/watchpack/lib/DirectoryWatcher.js:101:9
    at Array.forEach (<anonymous>)
    at DirectoryWatcher.setFileTime (/project/node_modules/watchpack/lib/DirectoryWatcher.js:99:42)
    at DirectoryWatcher.onChange (/project/node_modules/watchpack/lib/DirectoryWatcher.js:264:7)
    at FSWatcher.emit (events.js:189:13)
    at FSWatcher.<anonymous> (/project/node_modules/watchpack/node_modules/chokidar/index.js:199:15)
    at /project/node_modules/watchpack/node_modules/chokidar/index.js:238:7
    at FSReqWrap.oncomplete (fs.js:155:5)
```
