### PR TITLE
Fix broken "Static HTML File" link

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -8,7 +8,7 @@ Recipes are snippets of code and useful tidbits that may be helpful to developer
 [Custom Headers](./custom-headers.md)<br/>
 [Multi Entry Setup](./multi-entry.md)<br/>
 [Proxies](./proxies.md)<br/>
-[Static HTML File](./external-html.md)<br/>
+[Static HTML File](./static-html-files.md)<br/>
 [Using a Dynamic Port](./dynamic-port.md)<br/>
 [Using an Internal IP Address](./internal-ip.md)<br/>
 [Watching Static Content](./watch-static-content.md)


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [x] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Point "Static HTML File" link to `static-html-files.md` instead of non-existent `external-html.md`.
