### PR TITLE
fix: add `background` property to `#${ns}-problems pre` css rule

### DIFF
--- a/lib/client/overlays/status.js
+++ b/lib/client/overlays/status.js
@@ -107,6 +107,7 @@ const css = `
 
 #${ns}-problems pre {
   color: #ddd;
+  background: #282d35;
   display: block;
   font-size: 1.3em;
 	font-family: 'Open Sans', Helvetica, Arial, sans-serif;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Add `background` property to styles for `#wps-status-problems pre`.

Fixes #121
