### PR TITLE
fix: do not send data when socket is not READY

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -29,9 +29,15 @@ const setupRoutes = function setupRoutes() {
   const connect = async (ctx) => {
     if (ctx.ws) {
       const socket = await ctx.ws();
+      const send = (data) => {
+        if (socket.readyState !== 1) {
+          return;
+        }
+        socket.send(data);
+      };
 
       socket.build = (compilerName = '<unknown>', { wpsId }) => {
-        socket.send(prep({ action: 'build', data: { compilerName, wpsId } }));
+        send(prep({ action: 'build', data: { compilerName, wpsId } }));
       };
 
       socket.done = (stats, { wpsId }) => {
@@ -41,14 +47,14 @@ const setupRoutes = function setupRoutes() {
           return;
         }
 
-        socket.send(prep({ action: 'done', data: { hash, wpsId } }));
+        send(prep({ action: 'done', data: { hash, wpsId } }));
 
         socket.lastHash = hash;
 
         const { errors = [], warnings = [] } = stats.toJson(statsOptions);
 
         if (errors.length || warnings.length) {
-          socket.send(
+          send(
             prep({
               action: 'problems',
               data: {
@@ -67,27 +73,20 @@ const setupRoutes = function setupRoutes() {
 
         if (options.hmr || options.liveReload) {
           const action = options.liveReload ? 'reload' : 'replace';
-          socket.send(prep({ action, data: { hash, wpsId } }));
+          send(prep({ action, data: { hash, wpsId } }));
         }
       };
 
       socket.invalid = (filePath = '<unknown>', compiler) => {
-        if (socket.readyState === 3) {
-          return;
-        }
-
         const context = compiler.context || compiler.options.context || process.cwd();
         const fileName = filePath.replace && filePath.replace(context, '') || filePath;
         const { wpsId } = compiler;
 
-        socket.send(prep({ action: 'invalid', data: { fileName, wpsId } }));
+        send(prep({ action: 'invalid', data: { fileName, wpsId } }));
       };
 
       socket.progress = (data) => {
-        if (socket.readyState !== 1) {
-          return;
-        }
-        socket.send(prep({ action: 'progress', data }));
+        send(prep({ action: 'progress', data }));
       };
 
       for (const event of events) {
@@ -98,7 +97,7 @@ const setupRoutes = function setupRoutes() {
         });
       }
 
-      socket.send(prep({ action: 'connected' }));
+      send(prep({ action: 'connected' }));
     }
   };
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Follow up to #113.

Even with the above fix, I encountered a similar issue, this time in the `invalid` handler:

```
uncaughtException Error: WebSocket is not open: readyState 2 (CLOSING)
     at WebSocket.send (/app/node_modules/webpack-plugin-serve/node_modules/ws/lib/websocket.js:322:19)
     at WebpackPluginServe.socket.invalid (/app/node_modules/webpack-plugin-serve/lib/routes.js:83:16)
     at WebpackPluginServe.emit (events.js:189:13)
     at invalid.tap (/app/node_modules/webpack-plugin-serve/lib/index.js:155:41)
     at SyncHook.eval (eval at create (/app/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:7:1)
     at Watchpack.watcher.compiler.watchFileSystem.watch (/app/node_modules/webpack/lib/Watching.js:139:33)
     at Object.onceWrapper (events.js:277:13)
     at Watchpack.emit (events.js:189:13)
     at Watchpack._onChange (/app/node_modules/watchpack/lib/watchpack.js:118:7)
     at Watchpack.<anonymous> (/app/node_modules/watchpack/lib/watchpack.js:99:8)
     at Watcher.emit (events.js:189:13)
     at /app/node_modules/watchpack/lib/DirectoryWatcher.js:109:7
     at Array.forEach (<anonymous>)
     at DirectoryWatcher.setFileTime (/app/node_modules/watchpack/lib/DirectoryWatcher.js:108:41)
     at DirectoryWatcher.onChange (/app/node_modules/watchpack/lib/DirectoryWatcher.js:264:7)
     at FSWatcher.emit (events.js:189:13)
     at FSWatcher.<anonymous> (/app/node_modules/watchpack/node_modules/chokidar/index.js:199:15)
     at /app/node_modules/watchpack/node_modules/chokidar/index.js:238:7
     at FSReqWrap.oncomplete (fs.js:155:5)
```

As suggested in https://github.com/shellscape/webpack-plugin-serve/pull/113#discussion_r257849798 I've wrapped `send` so the error should not come back anymore.
