### PR TITLE
fix: assert localhost when server address doesnt match. fixes #131

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -109,11 +109,16 @@ const start = async function start() {
 
   address.hostname = address.address;
 
+  // fix #131 - server address reported as 127.0.0.1 for localhost
+  if (address.hostname !== this.options.host && this.options.host === 'localhost') {
+    address.hostname = this.options.host;
+  }
+
   // we set this so the client can use the actual hostname of the server. sometimes the net
   // will mutate the actual hostname value (e.g. :: -> [::])
   this.options.address = url.format(address);
 
-  const uri = `${protocol}://${url.format(this.options.address)}`;
+  const uri = `${protocol}://${this.options.address}`;
 
   this.log.info('Server Listening on:', uri);
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

There is potential for breakage if users were performing checks to work around this issue, or were expecting the incorrect address in an event hook.

### Please Describe Your Changes

#131 outlines a problem whereby `localhost` is rewritten to `127.0.0.1` after the server has been started and reports the address. That address is used to construct the URI for both console output and the `open` feature. In the referenced issue's case, a whitelist was being used and `127.0.0.1` was not on that list. The mismatch was unexpected.

This commit catches that discrepancy and rewrites the hostname portion of the url data to `localhost`.