### PR TITLE
Allow event for manually triggering a reload.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -135,6 +135,18 @@ class WebpackPluginServe extends EventEmitter {
     return result;
   }
 
+  // #138. handle emitted events that don't have a listener registered so they can be sent via WebSocket
+  emit(eventName, ...args) {
+    const listeners = this.eventNames();
+
+    if (listeners.includes(eventName)) {
+      super.emit(eventName, ...args);
+    } else {
+      const [data] = args;
+      super.emit('unhandled', { eventName, data });
+    }
+  }
+
   hook(compiler) {
     const { done, invalid, watchClose, watchRun } = compiler.hooks;
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -25,7 +25,7 @@ const statsOptions = {
 
 const setupRoutes = function setupRoutes() {
   const { app, options } = this;
-  const events = ['build', 'done', 'invalid', 'progress'];
+  const events = ['build', 'done', 'invalid', 'progress', 'reload'];
   const connect = async (ctx) => {
     if (ctx.ws) {
       const socket = await ctx.ws();
@@ -87,6 +87,13 @@ const setupRoutes = function setupRoutes() {
 
       socket.progress = (data) => {
         send(prep({ action: 'progress', data }));
+      };
+      
+      socket.reload = (data) => {
+        if (options.hmr || options.liveReload) {
+          const action = options.liveReload ? 'reload' : 'replace';
+          send(prep({ action, data }));
+        }
       };
 
       for (const event of events) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -25,7 +25,7 @@ const statsOptions = {
 
 const setupRoutes = function setupRoutes() {
   const { app, options } = this;
-  const events = ['build', 'done', 'invalid', 'progress', 'reload'];
+  const events = ['build', 'done', 'invalid', 'progress'];
   const connect = async (ctx) => {
     if (ctx.ws) {
       const socket = await ctx.ws();
@@ -34,13 +34,6 @@ const setupRoutes = function setupRoutes() {
           return;
         }
         socket.send(data);
-      };
-      
-      const reload = (data) => {
-        if (options.hmr || options.liveReload) {
-          const action = options.liveReload ? 'reload' : 'replace';
-          send(prep({ action, data }));
-        }
       };
 
       socket.build = (compilerName = '<unknown>', { wpsId }) => {
@@ -78,12 +71,15 @@ const setupRoutes = function setupRoutes() {
           }
         }
 
-        reload({ hash, wpsId })
+        if (options.hmr || options.liveReload) {
+          const action = options.liveReload ? 'reload' : 'replace';
+          send(prep({ action, data: { hash, wpsId } }));
+        }
       };
 
       socket.invalid = (filePath = '<unknown>', compiler) => {
         const context = compiler.context || compiler.options.context || process.cwd();
-        const fileName = filePath.replace && filePath.replace(context, '') || filePath;
+        const fileName = (filePath.replace && filePath.replace(context, '')) || filePath;
         const { wpsId } = compiler;
 
         send(prep({ action: 'invalid', data: { fileName, wpsId } }));
@@ -91,10 +87,6 @@ const setupRoutes = function setupRoutes() {
 
       socket.progress = (data) => {
         send(prep({ action: 'progress', data }));
-      };
-      
-      socket.reload = (data) => {
-        reload(data);
       };
 
       for (const event of events) {
@@ -104,6 +96,10 @@ const setupRoutes = function setupRoutes() {
           this.removeListener(event, socket[event]);
         });
       }
+
+      // #138. handle emitted events that don't have a listener registered, and forward the message
+      // onto the client via the socket
+      this.on('unhandled', ({ eventName, data }) => send(prep({ action: eventName, data })));
 
       send(prep({ action: 'connected' }));
     }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -35,6 +35,13 @@ const setupRoutes = function setupRoutes() {
         }
         socket.send(data);
       };
+      
+      const reload = (data) => {
+        if (options.hmr || options.liveReload) {
+          const action = options.liveReload ? 'reload' : 'replace';
+          send(prep({ action, data }));
+        }
+      };
 
       socket.build = (compilerName = '<unknown>', { wpsId }) => {
         send(prep({ action: 'build', data: { compilerName, wpsId } }));
@@ -71,10 +78,7 @@ const setupRoutes = function setupRoutes() {
           }
         }
 
-        if (options.hmr || options.liveReload) {
-          const action = options.liveReload ? 'reload' : 'replace';
-          send(prep({ action, data: { hash, wpsId } }));
-        }
+        reload({ hash, wpsId })
       };
 
       socket.invalid = (filePath = '<unknown>', compiler) => {
@@ -90,10 +94,7 @@ const setupRoutes = function setupRoutes() {
       };
       
       socket.reload = (data) => {
-        if (options.hmr || options.liveReload) {
-          const action = options.liveReload ? 'reload' : 'replace';
-          send(prep({ action, data }));
-        }
+        reload(data);
       };
 
       for (const event of events) {

--- a/recipes/watch-static-content.md
+++ b/recipes/watch-static-content.md
@@ -69,7 +69,9 @@ serve.on('listening', () => {
 });
 ```
 
-The important change there is `serve.emit('reload')`. We're including some sugar data there so that any listeners know where the event originated. That could be useful in an app that has multiple instruction points calling for reloads.
+The important change there is `serve.emit('reload')`. The `reload` event isn't actually handled by the `WebpackPluginServe` instance, but the plugin _does_ forward on unhandled, emitted events to all connected `WebSocket`s. The `reload` event is already handled in the client scripts as part of the `liveReload` option, so we can utilize that `WebSocket` message to reload the page. Alternatively, you might choose to connect your own `WebSocket`, use a different action (such as `static-change`), and add more magic than a plain old `window.location.reload()`.
+
+We're also including some sugar data there in `{source: 'config' }` so that any listeners know where the event originated. That could be useful in an app that has multiple instruction points calling for reloads.
 
 ### 🍰 Dessert
 


### PR DESCRIPTION
This PR contains:

- [?] bugfix
- [?] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes
This change allows the recipe described here to work: https://github.com/shellscape/webpack-plugin-serve/blob/master/recipes/watch-static-content.md

It basically enables the "reload" event to be emitted so that a reload can manually be triggered. 
