### PR TITLE
fix: flash of progress bar on page load

### DIFF
--- a/lib/client/overlays/progress-minimal.js
+++ b/lib/client/overlays/progress-minimal.js
@@ -51,8 +51,8 @@ const reset = (wrapper) => {
 const init = (options, socket) => {
   if (options.firstInstance) {
     document.addEventListener('DOMContentLoaded', () => {
-      addHtml(html);
       addCss(css);
+      addHtml(html);
     });
   }
 

--- a/lib/client/overlays/progress.js
+++ b/lib/client/overlays/progress.js
@@ -85,15 +85,19 @@ const css = `
 	}
 }
 
-.${ns}-hidden{
+.${ns}-hidden {
   animation: ${ns}-hidden-display .3s;
   animation-fill-mode:forwards;
   display: inline-flex;
 }
+
+.${ns}-hidden-onload {
+  display: none;
+}
 `;
 
 const html = `
-<svg id="${ns}" class="${ns}-noselect ${ns}-hidden" x="0px" y="0px" viewBox="0 0 80 80">
+<svg id="${ns}" class="${ns}-noselect ${ns}-hidden-onload" x="0px" y="0px" viewBox="0 0 80 80">
   <circle id="${ns}-bg" cx="50%" cy="50%" r="35"></circle>
   <path id="${ns}-fill" d="M5,40a35,35 0 1,0 70,0a35,35 0 1,0 -70,0" />
   <text id="${ns}-percent" x="50%" y="51%"><tspan id="${ns}-percent-value">0</tspan><tspan id="${ns}-percent-super">%</tspan></text>
@@ -138,7 +142,7 @@ const init = (options, socket) => {
     }
 
     // we can safely call this even if it doesn't have the class
-    svg.classList.remove(`${ns}-hidden`);
+    svg.classList.remove(`${ns}-hidden`, `${ns}-hidden-onload`);
 
     if (data.percent === 1) {
       setTimeout(() => reset(svg), 5e3);


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

### Please Describe Your Changes

- Fix flash of progress bar on initial page load(https://github.com/shellscape/webpack-plugin-serve/issues/96#issuecomment-457926404)
- Reorder `addCss` and `addHtml` in mini progress bar

I will create another PR for the progress bar disappear timeout issue, because page visibility API has its own problems.
