### PR TITLE
chore: rename package 'opn' to 'open' 

### DIFF
--- a/.github/FEATURES.md
+++ b/.github/FEATURES.md
@@ -51,7 +51,7 @@ The grid below represents a comparison of features from the available and most u
 - Host and Port can be set to a `Promise`, which allows for dynamic host and port resolution before the server starts.
 - The client (browser) WebSocket host can be set, allowing full customization for contain environments.
 - Fully customizable middleware, including execution order of built-in middleware. Users may implement whichever middleware they desire in the order which works best for them.
-- Leverages the `opn` module and all of it's available options, without restriction, for opening the target application in the browser automatically.
+- Leverages the `open` module and all of it's available options, without restriction, for opening the target application in the browser automatically.
 - A themed, UX-consistent Build Status (errors, warnings) overlay with minimized beacon mode for monitoring the status of builds during editing.
 - A themed, UX-consistent set of Build Progress overlay+indicator, with minimal option.
 - Superior serverless WebSocket connectivity.

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The `builtins` parameter provides access to all of the underlying middleware tha
 Type: `boolean | Object`<br>
 Default: `false`
 
-If `true`, opens the default browser to the set `host` and `port`. Users may also choose to pass an `Object` containing options for the [`opn`](https://github.com/sindresorhus/opn) module, which is used for this feature.
+If `true`, opens the default browser to the set `host` and `port`. Users may also choose to pass an `Object` containing options for the [`open`](https://github.com/sindresorhus/open) module, which is used for this feature.
 
 ### `port`
 Type: `Number | Promise`<br>

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,7 +11,7 @@
 const url = require('url');
 const { createServer, ServerResponse } = require('http');
 
-const open = require('opn');
+const open = require('open');
 
 const { getBuiltins } = require('./middleware');
 const { setupRoutes } = require('./routes');

--- a/package-lock.json
+++ b/package-lock.json
@@ -8608,10 +8608,10 @@
       "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
       "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q="
     },
-    "opn": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
-      "integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
+    "open": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
       "requires": {
         "is-wsl": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "loglevelnext": "^3.0.0",
     "nanoid": "^2.0.0",
     "onetime": "^5.1.0",
-    "opn": "^6.0.0",
+    "open": "^6.0.0",
     "p-defer": "^3.0.0",
     "read-pkg-up": "^6.0.0",
     "rimraf": "^2.6.3",

--- a/recipes/open-custom-uri.md
+++ b/recipes/open-custom-uri.md
@@ -2,14 +2,14 @@
 
 The [`open`](https://github.com/shellscape/webpack-plugin-serve#open) option provides users with the ability to instruct the plugin to open the root URI of an application after the server begins listening. In some circumstances users might need to open a custom URI. This can be done relatively quickly.
 
-_Note: `webpack-plugin-serve` endeavors to directly pass-through options for dependencies, rather than wrap custom options sets, parse them, and pass them onto dependencies. Such is the case for the `opn` module and the `open` option._
+_Note: `webpack-plugin-serve` endeavors to directly pass-through options for dependencies, rather than wrap custom options sets, parse them, and pass them onto dependencies. Such is the case for the `open` module and the `open` option._
 
 ### Meat and Potatoes
 
 To get started, your `webpack` configuration should already be setup and building successfully without using `webpack-plugin-serve`. Next, let's get the plugin setup for opening a custom URI:
 
 ```js
-const open = require('opn');
+const open = require('open');
 const { WebpackPluginServe } = require('webpack-plugin-serve');
 
 const serve = new WebpackPluginServe();
@@ -18,7 +18,7 @@ const serve = new WebpackPluginServe();
 serve.on('listening', () => {
   const uri = 'http://localhost:5555/#/local';
   const opts = {};
-  opn(uri, opts);
+  open(uri, opts);
 });
 
 // webpack.config.js


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] sort of
- [ ] no

If yes, please describe the breakage.

The dependency 'opn' is dropped in favor of 'open'.

### Please Describe Your Changes

Users get this warning every time they run `npm install`:
_npm WARN deprecated opn@6.0.0: The package has been renamed to `open`_

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
