### PR TITLE
fix: check that publicPath exists in static paths. fixes #100

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,10 @@
   included in all copies or substantial portions of this Source Code Form.
 */
 const EventEmitter = require('events');
+const { existsSync } = require('fs');
+const { join } = require('path');
 
+const chalk = require('chalk');
 const globby = require('globby');
 const Koa = require('koa');
 const nanoid = require('nanoid/generate');
@@ -179,6 +182,24 @@ class WebpackPluginServe extends EventEmitter {
 
     if (!this.options.static.length) {
       this.options.static.push(compiler.context);
+    }
+
+    // check static paths for publicPath. #100
+    const { publicPath } = compiler.options.output;
+    let foundPath = false;
+    for (const path of this.options.static) {
+      const joined = join(path, publicPath);
+      if (existsSync(joined)) {
+        foundPath = true;
+        break;
+      }
+    }
+
+    /* istanbul ignore next */
+    if (!foundPath) {
+      this.log.warn(
+        chalk`{bold {yellow Warning}} The value of {yellow \`output.publicPath\`} was not found on the filesystem in any static paths specified\n`
+      );
     }
 
     // we do this emit because webpack caches and optimizes the hooks, so there's no way to detach


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

This is more of a tertiary fix for #100. It's helpful to the user to know if their defined `publicPath` doesn't match/exist-in any of the static paths defined in the `static` option. That can cause issues and frustration related to #100. 