### PR TITLE
Lower status level when HMR is inactive

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -95,7 +95,7 @@ const run = (buildHash, options) => {
         info('Live Reload taking precedence over Hot Module Replacement');
       }
     } else {
-      warn('Hot Module Replacement is inactive');
+      info('Hot Module Replacement is inactive');
     }
 
     if (!module.hot && options.liveReload) {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

I have HMR disabled, and LiveReload enabled:

```js
{
  hmr: false,
  liveReload: true,
}
```

Plugin shows me a warning in a console, like something wrong with a configuration.

<img width="488" alt="Screen Shot 2019-12-05 at 12 44 43" src="https://user-images.githubusercontent.com/654597/70232827-9193c780-175d-11ea-8649-b10f81a36e5c.png">

This change makes message about disabled HRM in line with other HMR/LiveReload messages:

<img width="488" alt="Screen Shot 2019-12-05 at 12 45 05" src="https://user-images.githubusercontent.com/654597/70232872-ac663c00-175d-11ea-8d97-9911829ba05b.png">
