### PR TITLE
Fix `log` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ If `true`, will instruct the client to perform a full page reload after each bui
 _Note: This option overrides any value set for the `hmr` option property._
 
 ### `log`
-Type: `String`<br>
+Type: `Object`<br>
 Default: `{ level: 'info' }`<br>
 Valid `level` Values: `'trace' | 'debug' | 'info' | 'warn' | 'error'`
 


### PR DESCRIPTION
`log` is an object that accepts `level` key which is the string

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [x] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

### Please Describe Your Changes

Just a little fix to the README: `log` was declared to be a `String`. Instead it is an object accepting `level` key, which is the actual String here.
