### PR TITLE
feat: Allow customizing ramdisk options

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,11 @@ If [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy), the modul
 If a value of `'minimal'` is set, the progress indicator will render as a small, colored bar at the top of the window. This can be useful when the default fancy progress indicator interferes with elements in the page.
 
 ### `ramdisk`
-Type: `boolean`<br>
+Type: `boolean | Object`<br>
 Default: `false`<br>
 Support: MacOS and Linux, Windows with WSL 2.0.
 
-If `true`, will apply [`webpack-plugin-ramdisk`](https://www.npmjs.com/package/webpack-plugin-ramdisk) to the build. `output` configuration does not have to be modified, a symlink will be created from the original output path to the output path on the ramdisk. _**Note:** This will remove an existing directory at the defined output path._
+If `true` or `Object` (options), will apply [`webpack-plugin-ramdisk`](https://www.npmjs.com/package/webpack-plugin-ramdisk) to the build. `output` configuration does not have to be modified, a symlink will be created from the original output path to the output path on the ramdisk. _**Note:** This will remove an existing directory at the defined output path._
 
 Leveraging this option can result in significant reduction of build time, which is especially useful when using `hmr: true` or `liveReload: true`. Typical build times can be cut by 25-32% or more depending on hardware and webpack configuration. This is also recommended for users with SSD, as it reduces hard disk thrashing.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -178,7 +178,7 @@ class WebpackPluginServe extends EventEmitter {
     }
 
     if (this.options.ramdisk) {
-      initRamdiskPlugin.call(this, compiler);
+      initRamdiskPlugin.call(this, compiler, this.options.ramdisk);
     }
 
     if (!this.options.static.length) {

--- a/lib/plugins/ramdisk.js
+++ b/lib/plugins/ramdisk.js
@@ -14,7 +14,6 @@ const { symlinkSync } = require('fs');
 const { basename, join, resolve } = require('path');
 
 const isCwd = require('is-path-cwd');
-const isObject = require('isobject');
 const readPkgUp = require('read-pkg-up');
 const rm = require('rimraf');
 const { WebpackPluginRamdisk } = require('webpack-plugin-ramdisk');
@@ -78,7 +77,7 @@ module.exports = {
 
     const defaultOptions = { name: 'wps' };
     const plugin = new WebpackPluginRamdisk(
-      isObject(options) ? { ...options, ...defaultOptions } : defaultOptions
+      typeof options === 'object' ? { ...options, ...defaultOptions } : defaultOptions
     );
     plugin.apply(compiler);
 

--- a/lib/plugins/ramdisk.js
+++ b/lib/plugins/ramdisk.js
@@ -14,6 +14,7 @@ const { symlinkSync } = require('fs');
 const { basename, join, resolve } = require('path');
 
 const isCwd = require('is-path-cwd');
+const isObject = require('isobject');
 const readPkgUp = require('read-pkg-up');
 const rm = require('rimraf');
 const { WebpackPluginRamdisk } = require('webpack-plugin-ramdisk');
@@ -21,7 +22,7 @@ const { WebpackPluginRamdisk } = require('webpack-plugin-ramdisk');
 const { PluginExistsError, RamdiskPathError } = require('../errors');
 
 module.exports = {
-  init(compiler) {
+  init(compiler, options) {
     const hasPlugin = compiler.options.plugins.some(
       (plugin) => plugin instanceof WebpackPluginRamdisk
     );
@@ -75,7 +76,10 @@ module.exports = {
 
     this.log.info(`Ramdisk enabled`);
 
-    const plugin = new WebpackPluginRamdisk({ name: 'wps' });
+    const defaultOptions = { name: 'wps' };
+    const plugin = new WebpackPluginRamdisk(
+      isObject(options) ? { ...options, ...defaultOptions } : defaultOptions
+    );
     plugin.apply(compiler);
 
     rm.sync(path);

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -61,7 +61,7 @@ module.exports = {
       // prettier-ignore
       port: [number().integer().max(65535), any().promise()],
       progress: [boolean(), string().valid('minimal')],
-      ramdisk: [boolean()],
+      ramdisk: [boolean(), object()],
       secure: any().forbidden(),
       // prettier-ignore
       static: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -2463,6 +2463,12 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
@@ -2648,6 +2654,12 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
@@ -2832,6 +2844,14 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "cache-content-type": {
@@ -3109,6 +3129,12 @@
           "requires": {
             "is-descriptor": "^0.1.0"
           }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
@@ -4025,6 +4051,12 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
@@ -6516,6 +6548,14 @@
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
         "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "has-values": {
@@ -7307,6 +7347,14 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "is-promise": {
@@ -7401,10 +7449,9 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -9567,6 +9614,14 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "object.assign": {
@@ -9588,6 +9643,14 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
       }
     },
     "object.values": {
@@ -11159,6 +11222,12 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
@@ -12059,6 +12128,12 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7448,11 +7448,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
-    "isobject": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
-    },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "http-proxy-middleware": "^1.0.3",
     "is-path-cwd": "^2.2.0",
     "is-promise": "^4.0.0",
+    "isobject": "^4.0.0",
     "koa": "^2.5.3",
     "koa-compress": "^4.0.1",
     "koa-connect": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "http-proxy-middleware": "^1.0.3",
     "is-path-cwd": "^2.2.0",
     "is-promise": "^4.0.0",
-    "isobject": "^4.0.0",
     "koa": "^2.5.3",
     "koa-compress": "^4.0.1",
     "koa-connect": "^2.0.1",

--- a/test/fixtures/ramdisk/custom-options.js
+++ b/test/fixtures/ramdisk/custom-options.js
@@ -1,0 +1,31 @@
+const { resolve } = require('path');
+
+const getPort = require('get-port');
+
+const { WebpackPluginServe: Serve } = require('../../../lib/');
+
+module.exports = {
+  context: __dirname,
+  entry: ['./app.js', 'webpack-plugin-serve/client'],
+  mode: 'development',
+  output: {
+    filename: './output.js',
+    path: resolve(__dirname, './output'),
+    publicPath: 'output/'
+  },
+  plugins: [
+    new Serve({
+      host: 'localhost',
+      port: getPort({ port: 55555 }),
+      ramdisk: {
+        bytes: 1024 * 1024
+      }
+    })
+  ],
+  resolve: {
+    alias: {
+      'webpack-plugin-serve/client': resolve(__dirname, '../../../client')
+    }
+  },
+  watch: true
+};

--- a/test/ramdisk.test.js
+++ b/test/ramdisk.test.js
@@ -41,6 +41,27 @@ test('ramdisk', async (t) => {
   proc.kill('SIGTERM');
 });
 
+test('ramdisk with options', async (t) => {
+  const proc = execa('wp', ['--config', 'ramdisk/custom-options.js'], {
+    cwd: resolve(fixturePath, '..')
+  });
+  const { stderr, stdout } = proc;
+  const pathTest = 'Build being written to ';
+  const doneTest = '[emitted]';
+
+  const path = await waitFor(pathTest, stdout);
+
+  t.regex(path, /(volumes|mnt)\/wps\/[a-f0-9]{32}\/output/i);
+
+  await waitFor(doneTest, stderr);
+
+  const exists = existsSync(join(fixturePath, 'output/output.js'));
+
+  t.truthy(exists);
+
+  proc.kill('SIGTERM');
+});
+
 test('context error', async (t) => {
   try {
     await execa('wp', ['--config', 'ramdisk/config-context-error.js'], {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This PR allows you to customize `ramdisk` options by letting the user pass an object containing the options to the `ramdisk` field.

I came by this requirement in a project where the development output doesn't fit the default ramdisk (it's a big build!).