### PR TITLE
HotModuleReplacementPlugin webpack's 5.10 error message

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,4 @@
+module.exports = {
+  getMajorVersion: (version) =>
+    typeof version === 'string' && version.includes('.') ? version.split('.')[0] : false
+};

--- a/lib/plugins/hmr.js
+++ b/lib/plugins/hmr.js
@@ -8,7 +8,9 @@
   The above copyright notice and this permission notice shall be
   included in all copies or substantial portions of this Source Code Form.
 */
-const { HotModuleReplacementPlugin } = require('webpack');
+const { HotModuleReplacementPlugin, version } = require('webpack');
+
+const { getMajorVersion } = require('../helpers');
 
 const { PluginExistsError } = require('../errors');
 
@@ -18,10 +20,17 @@ const addPlugin = (compiler) => {
 };
 
 const init = function init(compiler, log) {
+  const webpackMajorVersion = getMajorVersion(version);
   // eslint-disable-next-line no-param-reassign
   compiler.options.output = Object.assign(compiler.options.output, {
-    hotUpdateChunkFilename: `[runtime]-${compiler.wpsId}-[id]-wps-hmr.js`,
-    hotUpdateMainFilename: `[runtime]-${compiler.wpsId}-wps-hmr.json`
+    hotUpdateChunkFilename:
+      webpackMajorVersion >= 5
+        ? `[runtime]-${compiler.wpsId}-[id]-wps-hmr.js`
+        : `${compiler.wpsId}-[id]-wps-hmr.js`,
+    hotUpdateMainFilename:
+      webpackMajorVersion >= 5
+        ? `[runtime]-${compiler.wpsId}-wps-hmr.json`
+        : `${compiler.wpsId}-wps-hmr.json`
   });
 
   const hasHMRPlugin = compiler.options.plugins.some(

--- a/lib/plugins/hmr.js
+++ b/lib/plugins/hmr.js
@@ -20,8 +20,8 @@ const addPlugin = (compiler) => {
 const init = function init(compiler, log) {
   // eslint-disable-next-line no-param-reassign
   compiler.options.output = Object.assign(compiler.options.output, {
-    hotUpdateChunkFilename: `${compiler.wpsId}-[id]-wps-hmr.js`,
-    hotUpdateMainFilename: `${compiler.wpsId}-wps-hmr.json`
+    hotUpdateChunkFilename: `[runtime]-${compiler.wpsId}-[id]-wps-hmr.js`,
+    hotUpdateMainFilename: `[runtime]-${compiler.wpsId}-wps-hmr.json`
   });
 
   const hasHMRPlugin = compiler.options.plugins.some(

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ci:coverage": "nyc npm run test && nyc report --reporter=text-lcov > coverage.lcov",
     "ci:lint": "npm run lint && npm run security",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
-    "ci:test": "npm run test -- --verbose",
+    "ci:test": "npm run test -- --verbose --timeout=30000",
     "commitlint": "commitlint",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "dev": "npm run dev:clean && node node_modules/webpack-nano/bin/wp --config test/fixtures/simple/webpack.config.js",

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,0 +1,13 @@
+const test = require('ava');
+
+const { getMajorVersion } = require('../lib/helpers');
+
+test('Get major version with correct value', (t) => {
+  const majorVersion = getMajorVersion('5.2.3');
+  t.true(majorVersion === '5');
+});
+
+test('Get major version with incorrect value', (t) => {
+  const majorVersion = getMajorVersion('5');
+  t.true(majorVersion === false);
+});


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

### Please Describe Your Changes

Since Webpack 5.10 has updated it starts showing an error message:

```shell script
HotModuleReplacementPlugin
The configured output.hotUpdateMainFilename doesn't lead to unique filenames per runtime and HMR update differs between runtimes.
This might lead to incorrect runtime behavior of the applied update.
To fix this, make sure to include [runtime] in the output.hotUpdateMainFilename option, or use the default config.
```
