### PR TITLE
Increase webpack peer depency from 4.20.2 to <6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-plugin-serve",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A Development Server in a Webpack Plugin",
   "license": "MPL-2.0",
   "repository": "shellscape/webpack-plugin-serve",
@@ -35,7 +35,7 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "webpack": "^4.20.2"
+    "webpack": ">=4.20.2 <6.0.0"
   },
   "dependencies": {
     "chalk": "^4.0.0",


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

Increase range of webpack peer dependency to accept installation on npm 7.

https://github.com/shellscape/webpack-plugin-serve/issues/195#issuecomment-775143719