### PR TITLE
Fixed documentation for Webpack output.library and libraryTarget: 'wi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ const options = { ... };
 module.exports = {
 	// an example entry definition
 	entry: [
-		'app.js',
 		'webpack-plugin-serve/client' // ← important: this is required, where the magic happens in the browser
+		'app.js'
 	]
   ...
   plugins: [


### PR DESCRIPTION
…ndow'

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [x] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

When building a library that exposes the main file exports to a variable ( for example window ) and use a multi entry config, only the last item in the entry array will be exposed. The example that was provided by the plugin would expose the webpack plugin serve client in the end file and it breaks the app.

An example of such configuration is:
```
// webpack.config.js
				output: {
					filename: `js/app.js`,
					library: ['zb', 'app'],
					libraryTarget: 'window'
				}
```
