### PR TITLE
Fix/error on hmr when file path is null

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ const options = { ... };
 module.exports = {
 	// an example entry definition
 	entry: [
-		'app.js',
 		'webpack-plugin-serve/client' // ← important: this is required, where the magic happens in the browser
+		'app.js'
 	]
   ...
   plugins: [

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -80,7 +80,7 @@ const setupRoutes = function setupRoutes() {
 
       socket.invalid = (filePath = '<unknown>', compiler) => {
         const context = compiler.context || compiler.options.context || process.cwd();
-        const fileName = (filePath.replace && filePath.replace(context, '')) || filePath;
+        const fileName = (filePath && filePath.replace && filePath.replace(context, '')) || filePath;
         const { wpsId } = compiler;
 
         send(prep({ action: 'invalid', data: { fileName, wpsId } }));


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The invalid hook from webpack filePath argument can be a string or null ( https://github.com/webpack/webpack/blob/64fb5f33f7b242fdbe8da453f793dbf95f4699e8/lib/Compiler.js#L168 ). This resolves a problem when the filePath is null ( the server throws an error and closes )