### PR TITLE
Fixed invalid chunkFileName

### DIFF
--- a/lib/plugins/hmr.js
+++ b/lib/plugins/hmr.js
@@ -23,10 +23,7 @@ const init = function init(compiler, log) {
   const webpackMajorVersion = getMajorVersion(version);
   // eslint-disable-next-line no-param-reassign
   compiler.options.output = Object.assign(compiler.options.output, {
-    hotUpdateChunkFilename:
-      webpackMajorVersion >= 5
-        ? `[runtime]-${compiler.wpsId}-[id]-wps-hmr.js`
-        : `${compiler.wpsId}-[id]-wps-hmr.js`,
+    hotUpdateChunkFilename: `${compiler.wpsId}-[id]-wps-hmr.js`,
     hotUpdateMainFilename:
       webpackMajorVersion >= 5
         ? `[runtime]-${compiler.wpsId}-wps-hmr.json`


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

As per Webpack documentation, [runtime] can be used only for hotUpdateMainFilename and not hotUpdateChunkFilename ( https://webpack.js.org/configuration/output/#outputhotupdatechunkfilename ). By having this template string inside outputhotupdatechunkfilename , the HMR breaks as chunk file names will have an incorrect name and the files won't be found on the server
