### PR TITLE
feat: Mark Webpack 5 as supported (#216)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "webpack": "^4.20.2"
+    "webpack": "^4.20.2 || ^5"
   },
   "dependencies": {
     "chalk": "^4.0.0",


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [x] metadata

### Breaking Changes?

- [ ] yes
- [x] no

### Please Describe Your Changes

Default Webpack version is now 5, discussed in #216.

Although considering the readme of this project suggests webpack-nano, perhaps a better option is to remove the peer dependency altogether.
