### PR TITLE
 Add `client.protocol` override option for client

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ Type: `String`
 
 If set, allows for overriding the `WebSocket` address, which corresponds to the server address by default. Values for this option should be in a valid `{host}:{port}` format. e.g. `localhost:433`.
 
+#### `client.protocol`
+Type: `String`
+
+If set, allows for overriding the `WebSocket` protocol scheme string, which corresponds to the server protocol scheme by default. Values for this option should be one of the following: `ws` or `wss`.
+
 #### `client.retry`
 Type: `Boolean`
 

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -23,8 +23,8 @@ const run = (buildHash, options) => {
   const { replace } = require('./hmr');
   const { error, info, warn } = require('./log')();
 
-  const protocol = secure ? 'wss' : 'ws';
-  const socket = new ClientSocket(client, `${protocol}://${client.address || address}/wps`);
+  const serverProtocol = secure ? 'wss' : 'ws';
+  const socket = new ClientSocket(client, `${client.protocol || serverProtocol}://${client.address || address}/wps`);
 
   const { compilerName } = options;
 

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -23,8 +23,8 @@ const run = (buildHash, options) => {
   const { replace } = require('./hmr');
   const { error, info, warn } = require('./log')();
 
-  const serverProtocol = secure ? 'wss' : 'ws';
-  const socket = new ClientSocket(client, `${client.protocol || serverProtocol}://${client.address || address}/wps`);
+  const protocol = secure ? 'wss' : 'ws';
+  const socket = new ClientSocket(client, `${client.protocol || protocol}://${client.address || address}/wps`);
 
   const { compilerName } = options;
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -35,6 +35,7 @@ module.exports = {
       allowMany: boolean(),
       client: partial({
         address: string(),
+        protocol: union([literal('ws'), literal('wss')]),
         retry: boolean(),
         silent: boolean()
       }),

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -10,8 +10,14 @@ test('defaults', (t) => {
 });
 
 test('client', (t) => {
-  const result = validate({ client: { address: '0', retry: false, silent: false } });
+  const result = validate({ client: { address: '0', protocol: "wss", retry: false, silent: false } });
   t.falsy(result.error);
+
+  const resultWs = validate({ client: { address: '0', protocol: "ws", retry: false, silent: false } });
+  t.falsy(resultWs.error);
+
+  const resultProtocolBad = validate({ client: { address: '0', protocol: "lala", retry: false, silent: false } });
+  t.truthy(resultProtocolBad.error);
 });
 
 test('error', (t) => {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [x] tests
- [x] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

Small, yet important (for me, at least :p) update: enables users of reverse proxies to specify a different protocol scheme for client requests (typically `wss` from the browser) from the protocol scheme served by the server (typically `ws`).

Provides the final, necessary tool to resolve: <https://github.com/shellscape/webpack-plugin-serve/issues/172>.