### PR TITLE
unregister "unhandled" event when socket is closed

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -100,7 +100,11 @@ const setupRoutes = function setupRoutes() {
 
       // #138. handle emitted events that don't have a listener registered, and forward the message
       // onto the client via the socket
-      this.on('unhandled', ({ eventName, data }) => send(prep({ action: eventName, data })));
+      const unhandled = ({ eventName, data }) => send(prep({ action: eventName, data }));
+      this.on('unhandled', unhandled);
+      socket.on('close', () => {
+        this.off('unhandled', unhandled);
+      });
 
       send(prep({ action: 'connected' }));
     }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes
I'm unsubscribing from this event whenever the socket is closed.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
This addresses the Memory Leak warning mentioned in #223