### PR TITLE
make sure wrapper is found before accessing the classList

### DIFF
--- a/lib/client/overlays/progress-minimal.js
+++ b/lib/client/overlays/progress-minimal.js
@@ -95,7 +95,9 @@ const init = (options, socket) => {
     const percent = Math.floor(data.percent * 100);
     const wrapper = document.querySelector(`#${ns}`);
 
-    wrapper.classList.remove(`${ns}-hidden`, `${ns}-disappear`);
+    if (wrapper) {
+      wrapper.classList.remove(`${ns}-hidden`, `${ns}-disappear`);
+    }
 
     if (data.percent === 1) {
       if (document.hidden) {


### PR DESCRIPTION
When used with https://github.com/pmmmwh/react-refresh-webpack-plugin this error shows up during incremental builds.
```Cannot read property 'classList' of null```

![Screen Shot 2021-05-20 at 3 31 01 PM](https://user-images.githubusercontent.com/30582/119057108-b810e700-b980-11eb-966b-6ec01c9b45d8.png)

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes
I've added a check for wrapper and if it's null, it won't try to access `classList`
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
