### PR TITLE
feat: Make package compatible with npm@7

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "webpack": "^4.20.2"
+    "webpack": "^4.20.2 || ^5.0.0"
   },
   "dependencies": {
     "chalk": "^4.0.0",


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

### Please Describe Your Changes

Allow webpack@5 as peerDependency so it don't install version 4 if not needed.

Related to: https://github.com/shellscape/webpack-plugin-serve/issues/216
