### PR TITLE
Preserve immutability for options.historyFallback

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -120,7 +120,7 @@ const getBuiltins = (app, options) => {
         await next();
       });
 
-      app.use(convert(historyApiFallback(options.historyFallback)));
+      app.use(convert(historyApiFallback({...options.historyFallback})));
     }
   };
 


### PR DESCRIPTION
Fixes https://github.com/shellscape/webpack-plugin-serve/issues/235 

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Resolves problems with DefinePlugin which throws warnings  because some variables are changed between rebuilds. The reason is that 3rd party middleware mutates options object passed to it.