### PR TITLE
fix(server): remove localhost check for address

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -104,7 +104,7 @@ const start = async function start() {
   address.hostname = address.address;
 
   // fix #131 - server address reported as 127.0.0.1 for localhost
-  if (address.hostname !== this.options.host && this.options.host === 'localhost') {
+  if (address.hostname !== this.options.host) {
     address.hostname = this.options.host;
   }
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
This is PR is related to an issue #239 
when using custom domain which is proxied to 127.0.0.1 as host in options 
In the logs it shows that Server is started at http://127.0.0.1:port instead of domain name. 
An explicit check was added for localhost at #132  but this check doesn't allow the use of custom domain names
